### PR TITLE
Fixing hub macro missing an alias in a subquery.

### DIFF
--- a/macros/tables/hub.sql
+++ b/macros/tables/hub.sql
@@ -52,7 +52,7 @@ STG AS (
                 UNION ALL
                 {%- endif %}
             {%- endfor %}
-            )
+            ) as all_sources
         WHERE {{ src_pk }} IS NOT NULL
     ) AS b
     WHERE RN = 1
@@ -77,7 +77,7 @@ STG AS (
 
 SELECT c.* FROM STG AS c
 {%- if is_incremental() %}
-LEFT JOIN {{ this }} AS d 
+LEFT JOIN {{ this }} AS d
 ON {{ dbtvault.prefix([src_pk], 'c') }} = {{ dbtvault.prefix([src_pk], 'd') }}
 WHERE {{ dbtvault.prefix([src_pk], 'd') }} IS NULL
 {%- endif -%}


### PR DESCRIPTION
This was preventing the macro to work on Postgres.