### PR TITLE
Added check_required_parameters tests in PIT & Bridge macros

### DIFF
--- a/dbtvault-dev/macros/tables/bridge.sql
+++ b/dbtvault-dev/macros/tables/bridge.sql
@@ -9,6 +9,11 @@
 
 {%- macro default__bridge(src_pk, as_of_dates_table, bridge_walk, stage_tables_ldts, src_ldts, source_model) -%}
 
+{{- dbtvault.check_required_parameters(source_model=source_model, src_pk=src_pk,
+                                       bridge_walk=bridge_walk,
+                                       stage_tables_ldts=stage_tables_ldts,
+                                       src_ldts=src_ldts) -}}
+
 {{ dbtvault.prepend_generated_by() }}
 
 {%- if (as_of_dates_table is none) and execute -%}

--- a/dbtvault-dev/macros/tables/pit.sql
+++ b/dbtvault-dev/macros/tables/pit.sql
@@ -11,13 +11,18 @@
 
 {%- macro default__pit(src_pk, as_of_dates_table, satellites, stage_tables, src_ldts, source_model) -%}
 
+{{- dbtvault.check_required_parameters(source_model=source_model, src_pk=src_pk,
+                                       satellites=satellites,
+                                       stage_tables=stage_tables,
+                                       src_ldts=src_ldts) -}}
+
 {{ dbtvault.prepend_generated_by() }}
 
 {% set adapter_type = dbtvault.get_adapter_type() %}
 
 {%- if (as_of_dates_table is none) and execute -%}
     {%- set error_message -%}
-    "pit error: Missing as_of_dates table configuration. A as_of_dates_table must be provided."
+    "PIT error: Missing as_of_dates table configuration. A as_of_dates_table must be provided."
     {%- endset -%}
     {{- exceptions.raise_compiler_error(error_message) -}}
 {%- endif -%}


### PR DESCRIPTION
The dbtvault.check_required_parameters call was missing from the the PIT and Bridge macros. 

Not included the `as_of_dates_table` parameter as it has it's own test.