### PR TITLE
should_full_refresh() in materializations

### DIFF
--- a/macros/materialisations/incremental_bridge_materialization.sql
+++ b/macros/materialisations/incremental_bridge_materialization.sql
@@ -1,6 +1,6 @@
 {% materialization bridge_incremental, default -%}
 
-  {% set full_refresh_mode = flags.FULL_REFRESH %}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}

--- a/macros/materialisations/incremental_pit_materialization.sql
+++ b/macros/materialisations/incremental_pit_materialization.sql
@@ -1,6 +1,6 @@
 {% materialization pit_incremental, default -%}
 
-  {% set full_refresh_mode = flags.FULL_REFRESH %}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}

--- a/macros/materialisations/vault_insert_by_period_materialization.sql
+++ b/macros/materialisations/vault_insert_by_period_materialization.sql
@@ -1,6 +1,6 @@
 {% materialization vault_insert_by_period, default -%}
 
-    {%- set full_refresh_mode = flags.FULL_REFRESH -%}
+    {%- set full_refresh_mode = (should_full_refresh()) -%}
 
     {%- set target_relation = this -%}
     {%- set existing_relation = load_relation(this) -%}

--- a/macros/materialisations/vault_insert_by_rank_materialization.sql
+++ b/macros/materialisations/vault_insert_by_rank_materialization.sql
@@ -1,6 +1,6 @@
 {% materialization vault_insert_by_rank, default -%}
 
-    {%- set full_refresh_mode = flags.FULL_REFRESH -%}
+    {%- set full_refresh_mode = (should_full_refresh()) -%}
 
     {%- set target_relation = this -%}
     {%- set existing_relation = load_relation(this) -%}


### PR DESCRIPTION
# Objective
- Use the should_full_refresh() macro when determining if a model should fully refresh

# Details
Currently, models that use Dbtvault materializations only respect the "--full-refresh" flag on the command line. DBT Core materializations like [incremental](https://github.com/dbt-labs/dbt-core/blob/8442fb66a591c4f5353f8baaaaf62f846c5f5171/core/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql#L9), however, use the [`should_full_refresh` macro](https://github.com/dbt-labs/dbt-core/blob/8442fb66a591c4f5353f8baaaaf62f846c5f5171/core/dbt/include/global_project/macros/materializations/configs.sql#L6) do determine if an individual model should fully refresh.

This MR changes Dbtvault materializations to use `should_full_refresh` like DBT Core materializations do.