### PR TITLE
Enhanced Hub macros to accommodate for collision keys

### DIFF
--- a/dbtvault-dev/macros/tables/bigquery/hub.sql
+++ b/dbtvault-dev/macros/tables/bigquery/hub.sql
@@ -1,15 +1,16 @@
-{%- macro bigquery__hub(src_pk, src_nk, src_ldts, src_source, source_model) -%}
+{%- macro bigquery__hub(src_pk, src_nk, src_ck, src_ldts, src_source, source_model) -%}
 
-{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk,
+{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk, src_ck=src_ck,
                                        src_ldts=src_ldts, src_source=src_source,
                                        source_model=source_model) -}}
 
 {%- set src_pk = dbtvault.escape_column_names(src_pk) -%}
 {%- set src_nk = dbtvault.escape_column_names(src_nk) -%}
+{%- set src_ck = dbtvault.escape_column_names(src_ck) -%}
 {%- set src_ldts = dbtvault.escape_column_names(src_ldts) -%}
 {%- set src_source = dbtvault.escape_column_names(src_source) -%}
 
-{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ldts, src_source]) -%}
+{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
     {%- set source_cols_with_rank = source_cols + dbtvault.escape_column_names([config.get('rank_column')]) -%}

--- a/dbtvault-dev/macros/tables/databricks/hub.sql
+++ b/dbtvault-dev/macros/tables/databricks/hub.sql
@@ -1,15 +1,16 @@
-{%- macro spark__hub(src_pk, src_nk, src_ldts, src_source, source_model) -%}
+{%- macro spark__hub(src_pk, src_nk, src_ck, src_ldts, src_source, source_model) -%}
 
-{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk,
+{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk, src_ck=src_ck,
                                        src_ldts=src_ldts, src_source=src_source,
                                        source_model=source_model) -}}
 
 {%- set src_pk = dbtvault.escape_column_names(src_pk) -%}
 {%- set src_nk = dbtvault.escape_column_names(src_nk) -%}
+{%- set src_ck = dbtvault.escape_column_names(src_ck) -%}
 {%- set src_ldts = dbtvault.escape_column_names(src_ldts) -%}
 {%- set src_source = dbtvault.escape_column_names(src_source) -%}
 
-{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ldts, src_source]) -%}
+{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
 
 SELECT '1'
 

--- a/dbtvault-dev/macros/tables/snowflake/hub.sql
+++ b/dbtvault-dev/macros/tables/snowflake/hub.sql
@@ -18,23 +18,13 @@
 {%- set src_ldts = dbtvault.escape_column_names(src_ldts) -%}
 {%- set src_source = dbtvault.escape_column_names(src_source) -%}
 
-{%- set source_cols_with_ck = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
-{%- set source_cols_without_ck = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ldts, src_source]) -%}
-{%- set source_cols = [] -%}
-
-{%- if dbtvault.is_nothing(src_ck) -%}
-    {%- set source_cols = source_cols + source_cols_without_ck -%}
-{%- else -%}
-    {%- set source_cols = source_cols + source_cols_with_ck -%}
-{%- endif -%}
+{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
     {%- set source_cols_with_rank = source_cols + dbtvault.escape_column_names([config.get('rank_column')]) -%}
 {%- endif -%}
 
 {{ dbtvault.prepend_generated_by() }}
-
-
 
 {{ 'WITH ' -}}
 

--- a/dbtvault-dev/macros/tables/snowflake/hub.sql
+++ b/dbtvault-dev/macros/tables/snowflake/hub.sql
@@ -1,23 +1,24 @@
-{%- macro hub(src_pk, src_nk, src_ldts, src_source, source_model) -%}
+{%- macro hub(src_pk, src_nk, src_ck, src_ldts, src_source, source_model) -%}
 
-    {{- adapter.dispatch('hub', 'dbtvault')(src_pk=src_pk, src_nk=src_nk,
+    {{- adapter.dispatch('hub', 'dbtvault')(src_pk=src_pk, src_nk=src_nk, src_ck=src_ck,
                                             src_ldts=src_ldts, src_source=src_source,
                                             source_model=source_model) -}}
 
 {%- endmacro -%}
 
-{%- macro default__hub(src_pk, src_nk, src_ldts, src_source, source_model) -%}
+{%- macro default__hub(src_pk, src_nk, src_ck, src_ldts, src_source, source_model) -%}
 
-{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk,
+{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk, src_ck=src_ck,
                                        src_ldts=src_ldts, src_source=src_source,
                                        source_model=source_model) -}}
 
 {%- set src_pk = dbtvault.escape_column_names(src_pk) -%}
 {%- set src_nk = dbtvault.escape_column_names(src_nk) -%}
+{%- set src_ck = dbtvault.escape_column_names(src_ck) -%}
 {%- set src_ldts = dbtvault.escape_column_names(src_ldts) -%}
 {%- set src_source = dbtvault.escape_column_names(src_source) -%}
 
-{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ldts, src_source]) -%}
+{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
     {%- set source_cols_with_rank = source_cols + dbtvault.escape_column_names([config.get('rank_column')]) -%}

--- a/dbtvault-dev/macros/tables/snowflake/hub.sql
+++ b/dbtvault-dev/macros/tables/snowflake/hub.sql
@@ -59,8 +59,7 @@ row_rank_{{ source_number }} AS (
                ORDER BY {{ dbtvault.prefix([src_ldts], 'rr') }}
            ) AS row_number
     FROM {{ ref(src) }} AS rr
-    {# changed from src_pk to src_nk to avoid bringing pks with null nk but non null ck #}
-    WHERE {{ dbtvault.multikey(src_nk, prefix='rr', condition='IS NOT NULL') }}
+    WHERE {{ dbtvault.multikey(src_pk, prefix='rr', condition='IS NOT NULL') }}
     QUALIFY row_number = 1
     {%- set ns.last_cte = "row_rank_{}".format(source_number) %}
 ),{{ "\n" if not loop.last }}

--- a/dbtvault-dev/macros/tables/sqlserver/hub.sql
+++ b/dbtvault-dev/macros/tables/sqlserver/hub.sql
@@ -1,15 +1,16 @@
-{%- macro sqlserver__hub(src_pk, src_nk, src_ldts, src_source, source_model) -%}
+{%- macro sqlserver__hub(src_pk, src_nk, src_ck, src_ldts, src_source, source_model) -%}
 
-{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk,
+{{- dbtvault.check_required_parameters(src_pk=src_pk, src_nk=src_nk, src_ck=src_ck,
                                        src_ldts=src_ldts, src_source=src_source,
                                        source_model=source_model) -}}
 
 {%- set src_pk = dbtvault.escape_column_names(src_pk) -%}
 {%- set src_nk = dbtvault.escape_column_names(src_nk) -%}
+{%- set src_ck = dbtvault.escape_column_names(src_ck) -%}
 {%- set src_ldts = dbtvault.escape_column_names(src_ldts) -%}
 {%- set src_source = dbtvault.escape_column_names(src_source) -%}
 
-{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ldts, src_source]) -%}
+{%- set source_cols = dbtvault.expand_column_list(columns=[src_pk, src_nk, src_ck, src_ldts, src_source]) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
     {%- set source_cols_with_rank = source_cols + dbtvault.escape_column_names([config.get('rank_column')]) -%}

--- a/test/dbtvault_generator.py
+++ b/test/dbtvault_generator.py
@@ -70,11 +70,12 @@ def stage(model_name, source_model: dict, derived_columns=None, hashed_columns=N
     template_to_file(template, model_name)
 
 
-def hub(model_name, src_pk, src_nk, src_ck, src_ldts, src_source, source_model, config, depends_on=""):
+def hub(model_name, src_pk, src_nk, src_ldts, src_source, source_model, config, depends_on="", src_ck=None):
     """
     Generate a hub model template
         :param model_name: Name of the model file
         :param src_pk: Source pk
+        :param src_ck: Collision Key
         :param src_nk: Source nk
         :param src_ldts: Source load date timestamp
         :param src_source: Source record source column

--- a/test/dbtvault_generator.py
+++ b/test/dbtvault_generator.py
@@ -70,7 +70,7 @@ def stage(model_name, source_model: dict, derived_columns=None, hashed_columns=N
     template_to_file(template, model_name)
 
 
-def hub(model_name, src_pk, src_nk, src_ldts, src_source, source_model, config, depends_on=""):
+def hub(model_name, src_pk, src_nk, src_ck, src_ldts, src_source, source_model, config, depends_on=""):
     """
     Generate a hub model template
         :param model_name: Name of the model file
@@ -86,7 +86,7 @@ def hub(model_name, src_pk, src_nk, src_ldts, src_source, source_model, config, 
     template = f"""
     {depends_on}    
     {{{{ config({config}) }}}}
-    {{{{ dbtvault.hub(src_pk={src_pk}, src_nk={src_nk}, 
+    {{{{ dbtvault.hub(src_pk={src_pk}, src_nk={src_nk}, src_ck={src_ck}, 
                       src_ldts={src_ldts}, src_source={src_source}, 
                       source_model={source_model})   }}}}
     """

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -73,6 +73,12 @@ fixtures_registry = {
          "sqlserver": fixtures_hub.multi_source_comppk_hub_sqlserver,
          "databricks": ''},
 
+    "fixture.multi_source_hub_with_collision_key":
+        {"snowflake": fixtures_hub.multi_source_hub_with_collision_key_snowflake,
+         "bigquery": fixtures_hub.multi_source_hub_with_collision_key_bigquery,
+         "sqlserver": fixtures_hub.multi_source_hub_with_collision_key_sqlserver,
+         "databricks": fixtures_hub.multi_source_hub_with_collision_key_databricks},
+
     "fixture.single_source_link":
         {"snowflake": fixtures_link.single_source_link_snowflake,
          "bigquery": fixtures_link.single_source_link_bigquery,

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -55,6 +55,12 @@ fixtures_registry = {
          "sqlserver": fixtures_hub.single_source_comppknk_hub_sqlserver,
          "databricks": ''},
 
+    "fixture.single_source_hub_with_collision_key":
+        {"snowflake": fixtures_hub.single_source_hub_with_collision_key_snowflake,
+         "bigquery": fixtures_hub.single_source_hub_with_collision_key_bigquery,
+         "sqlserver": fixtures_hub.single_source_hub_with_collision_key_sqlserver,
+         "databricks": fixtures_hub.single_source_hub_with_collision_key_databricks},
+
     "fixture.multi_source_hub":
         {"snowflake": fixtures_hub.multi_source_hub_snowflake,
          "bigquery": fixtures_hub.multi_source_hub_bigquery,

--- a/test/features/hubs/fixtures_hub.py
+++ b/test/features/hubs/fixtures_hub.py
@@ -337,6 +337,82 @@ def multi_source_comppk_hub_snowflake(context):
     }
 
 
+@fixture
+def multi_source_hub_with_collision_key_snowflake(context):
+    """
+    Define the structures and metadata to load multi-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER_A": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_B": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_C": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER_A": {
+            "COLLISION_KEY": "!A"
+        },
+        "STG_CUSTOMER_B": {
+            "COLLISION_KEY": "!B"
+        },
+        "STG_CUSTOMER_C": {
+            "COLLISION_KEY": "!C"
+        }
+    }
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(16)",
+                "CUSTOMER_ID": "VARCHAR",
+                "COLLISION_KEY": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        },
+        "RAW_STAGE_A": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR",
+                "CUSTOMER_NAME": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        },
+        "RAW_STAGE_B": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR",
+                "CUSTOMER_NAME": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        },
+        "RAW_STAGE_C": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR",
+                "CUSTOMER_NAME": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        }
+    }
+
+
 # BigQuery
 
 
@@ -667,6 +743,83 @@ def multi_source_comppk_hub_bigquery(context):
                 "QUANTITY": "FLOAT",
                 "EXTENDED_PRICE": "NUMERIC",
                 "DISCOUNT": "NUMERIC",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        }
+    }
+
+
+@fixture
+def multi_source_hub_with_collision_key_bigquery(context):
+    """
+    Define the structures and metadata to load multi-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER_A": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_B": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_C": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER_A": {
+            "COLLISION_KEY": "!A"
+        },
+        "STG_CUSTOMER_B": {
+            "COLLISION_KEY": "!B"
+        },
+        "STG_CUSTOMER_C": {
+            "COLLISION_KEY": "!C"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "STRING",
+                "CUSTOMER_ID": "STRING",
+                "COLLISION_KEY": "STRING",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        },
+        "RAW_STAGE_A": {
+            "column_types": {
+                "CUSTOMER_ID": "STRING",
+                "CUSTOMER_NAME": "STRING",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        },
+        "RAW_STAGE_B": {
+            "column_types": {
+                "CUSTOMER_ID": "STRING",
+                "CUSTOMER_NAME": "STRING",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        },
+        "RAW_STAGE_C": {
+            "column_types": {
+                "CUSTOMER_ID": "STRING",
+                "CUSTOMER_NAME": "STRING",
                 "LOAD_DATE": "DATE",
                 "SOURCE": "STRING"
             }
@@ -1100,6 +1253,85 @@ def multi_source_comppk_hub_sqlserver(context):
     }
 
 
+@fixture
+def multi_source_hub_with_collision_key_sqlserver(context):
+    """
+    Define the structures and metadata to load multi-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER_A": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_B": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_C": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER_A": {
+            "COLLISION_KEY": "!A"
+        },
+        "STG_CUSTOMER_B": {
+            "COLLISION_KEY": "!B"
+        },
+        "STG_CUSTOMER_C": {
+            "COLLISION_KEY": "!C"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(16)",
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "RAW_STAGE_A": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "CUSTOMER_NAME": "VARCHAR(5)",
+                "CUSTOMER_DOB": "DATE",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "RAW_STAGE_B": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "CUSTOMER_NAME": "VARCHAR(5)",
+                "CUSTOMER_DOB": "DATE",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "RAW_STAGE_C": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "CUSTOMER_NAME": "VARCHAR(5)",
+                "CUSTOMER_DOB": "DATE",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        }
+    }
+
+
 # Databricks
 
 
@@ -1264,6 +1496,83 @@ def multi_source_hub_databricks(context):
                 "DISCOUNT": "NUMBER(38,2)",
                 "LOAD_DATE": "DATE",
                 "SOURCE": "VARCHAR"
+            }
+        }
+    }
+
+
+@fixture
+def multi_source_hub_with_collision_key_databricks(context):
+    """
+    Define the structures and metadata to load multi-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER_A": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_B": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_C": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER_A": {
+            "COLLISION_KEY": "!A"
+        },
+        "STG_CUSTOMER_B": {
+            "COLLISION_KEY": "!B"
+        },
+        "STG_CUSTOMER_C": {
+            "COLLISION_KEY": "!C"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY",
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "COLLISION_KEY": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
+            }
+        },
+        "RAW_STAGE_A": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "CUSTOMER_NAME": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
+            }
+        },
+        "RAW_STAGE_B": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "CUSTOMER_NAME": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
+            }
+        },
+        "RAW_STAGE_C": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "CUSTOMER_NAME": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
             }
         }
     }

--- a/test/features/hubs/fixtures_hub.py
+++ b/test/features/hubs/fixtures_hub.py
@@ -134,6 +134,54 @@ def single_source_comppknk_hub_snowflake(context):
 
 
 @fixture
+def single_source_hub_with_collision_key_snowflake(context):
+    """
+    Define the structures and metadata to load single-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER": {
+            "COLLISION_KEY": "!A"
+        }
+    }
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(16)",
+                "CUSTOMER_ID": "VARCHAR",
+                "COLLISION_KEY": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        },
+        "RAW_STAGE": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR",
+                "CUSTOMER_NAME": "VARCHAR",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR"
+            }
+        }
+    }
+
+
+@fixture
 def multi_source_hub_snowflake(context):
     """
     Define the structures and metadata to load multi-source hubs
@@ -413,6 +461,55 @@ def single_source_comppknk_hub_bigquery(context):
             "column_types": {
                 "CUSTOMER_ID": "STRING",
                 "CUSTOMER_CK": "STRING",
+                "CUSTOMER_NAME": "STRING",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        }
+    }
+
+
+@fixture
+def single_source_hub_with_collision_key_bigquery(context):
+    """
+    Define the structures and metadata to load single-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER": {
+            "COLLISION_KEY": "!A"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "STRING",
+                "CUSTOMER_ID": "STRING",
+                "COLLISION_KEY": "STRING",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "STRING"
+            }
+        },
+        "RAW_STAGE": {
+            "column_types": {
+                "CUSTOMER_ID": "STRING",
                 "CUSTOMER_NAME": "STRING",
                 "LOAD_DATE": "DATE",
                 "SOURCE": "STRING"
@@ -761,6 +858,93 @@ def single_source_comppknk_hub_sqlserver(context):
 
 
 @fixture
+def single_source_hub_with_collision_key_sqlserver(context):
+    """
+    Define the structures and metadata to load single-source hubs with collision keys
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        },
+        "STG_CUSTOMER_HASHLIST": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID", "CUSTOMER_NAME"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER": {
+            "COLLISION_KEY": "!A"
+        },
+        "STG_CUSTOMER_HASHLIST": {
+            "COLLISION_KEY": "!A"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB_CUSTOMER": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        },
+        "HUB_CUSTOMER_SHA": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        },
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB_CUSTOMER": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(16)",
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "COLLISION_KEY": "VARCHAR(4)",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "HUB_CUSTOMER_SHA": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(32)",
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "COLLISION_KEY": "VARCHAR(4)",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY(16)",
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        },
+        "RAW_STAGE": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(4)",
+                "CUSTOMER_NAME": "VARCHAR(5)",
+                "CUSTOMER_DOB": "DATE",
+                "LOAD_DATE": "DATETIME2",
+                "SOURCE": "VARCHAR(4)"
+            }
+        }
+    }
+
+
+@fixture
 def multi_source_hub_sqlserver(context):
     """
     Define the structures and metadata to load multi-source hubs
@@ -945,6 +1129,55 @@ def single_source_hub_databricks(context):
             "column_types": {
                 "CUSTOMER_PK": "BINARY",
                 "CUSTOMER_ID": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
+            }
+        },
+        "RAW_STAGE": {
+            "column_types": {
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "CUSTOMER_NAME": "VARCHAR(100)",
+                "LOAD_DATE": "DATE",
+                "SOURCE": "VARCHAR(100)"
+            }
+        }
+    }
+
+
+@fixture
+def single_source_hub_with_collision_key_databricks(context):
+    """
+    Define the structures and metadata to load single-source hubs
+    """
+
+    context.hashed_columns = {
+        "STG_CUSTOMER": {
+            "CUSTOMER_PK": ["COLLISION_KEY", "CUSTOMER_ID"]
+        }
+    }
+
+    context.derived_columns = {
+        "STG_CUSTOMER": {
+            "COLLISION_KEY": "!A"
+        }
+    }
+
+    context.vault_structure_columns = {
+        "HUB": {
+            "src_pk": "CUSTOMER_PK",
+            "src_nk": "CUSTOMER_ID",
+            "src_ck": "COLLISION_KEY",
+            "src_ldts": "LOAD_DATE",
+            "src_source": "SOURCE"
+        }
+    }
+
+    context.seed_config = {
+        "HUB": {
+            "column_types": {
+                "CUSTOMER_PK": "BINARY",
+                "CUSTOMER_ID": "VARCHAR(100)",
+                "COLLISION_KEY": "VARCHAR(100)",
                 "LOAD_DATE": "DATE",
                 "SOURCE": "VARCHAR(100)"
             }

--- a/test/features/hubs/hubs_collision_key.feature
+++ b/test/features/hubs/hubs_collision_key.feature
@@ -1,7 +1,7 @@
 Feature: [HUB-CK] Hubs - Collision Keys
 
   @fixture.single_source_hub_with_collision_key
-  Scenario: [HUB-CK-01] Simple load of stage data into an empty hub with collision keys
+  Scenario: [HUB-CK-01] Simple load of stage data into non existent hub with collision keys
     Given the HUB table does not exist
     And the RAW_STAGE table contains data
       | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
@@ -21,8 +21,125 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
 
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-02] Keys with NULL or empty values are not loaded into non existent hub with collision key that does not exist
+    Given the HUB table does not exist
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+      | <null>      | Frida         | 1993-01-01 | TPCH   |
+      |             | George        | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-03] Simple load of stage data into an empty hub with collision keys
+    Given the HUB hub is empty
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-04] Keys with NULL or empty values are not loaded into empty hub with collision key that does not exist
+    Given the HUB hub is empty
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+      | <null>      | Frida         | 1993-01-01 | TPCH   |
+      |             | George        | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-05] Simple load of stage data into a populated hub with collision keys
+    Given the HUB hub is already populated with data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1003        | Chad          | 1993-01-02 | TPCH   |
+      | 1004        | Dom           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-02 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-02 | TPCH   |
+
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-06] Keys with NULL or empty values are not loaded into populated hub with collision key that does not exist
+    Given the HUB hub is already populated with data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1003        | Chad          | 1993-01-02 | TPCH   |
+      | 1004        | Dom           | 1993-01-02 | TPCH   |
+      | <null>      | Frida         | 1993-01-02 | TPCH   |
+      |             | George        | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-02 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-02 | TPCH   |
+
   @fixture.multi_source_hub_with_collision_key
-  Scenario: [HUB-CK-02] Simple load of identical stage data from multiple sources into an empty hub with collision keys
+  Scenario: [HUB-CK-07] Simple load of identical stage data from multiple sources into a non existent hub with collision keys
     Given the HUB table does not exist
     And the RAW_STAGE_A table contains data
       | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
@@ -38,21 +155,21 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
       | 1001        | Alice         | 1993-01-01 | TPCH   |
       | 1001        | Alice         | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1003        | Chad          | 1993-01-01 | TPCH   |
-      | 1004        | Dom           | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1013        | Chaz          | 1993-01-01 | TPCH   |
+      | 1014        | Don           | 1993-01-01 | TPCH   |
     And I stage the STG_CUSTOMER_B data
     And the RAW_STAGE_C table contains data
       | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
       | 1001        | Alice         | 1993-01-01 | TPCH   |
       | 1001        | Alice         | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1002        | Bob           | 1993-01-01 | TPCH   |
-      | 1003        | Chad          | 1993-01-01 | TPCH   |
-      | 1004        | Dom           | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1023        | Chat          | 1993-01-01 | TPCH   |
+      | 1024        | Doc           | 1993-01-01 | TPCH   |
     And I stage the STG_CUSTOMER_C data
     When I load the HUB hub
     Then the HUB table should contain expected data
@@ -62,11 +179,234 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
       | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
-      | md5('B\|\|1002') | 1002        | B             | 1993-01-01 | TPCH   |
-      | md5('B\|\|1003') | 1003        | B             | 1993-01-01 | TPCH   |
-      | md5('B\|\|1004') | 1004        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1013') | 1013        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1014') | 1014        | B             | 1993-01-01 | TPCH   |
       | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
-      | md5('C\|\|1002') | 1002        | C             | 1993-01-01 | TPCH   |
-      | md5('C\|\|1003') | 1003        | C             | 1993-01-01 | TPCH   |
-      | md5('C\|\|1004') | 1004        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1023') | 1023        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1024') | 1024        | C             | 1993-01-01 | TPCH   |
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-08]  Keys with NULL or empty values are not loaded into a multi sourced non existent hub with collision keys
+    Given the HUB table does not exist
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | <null>      | Chad          | 1993-01-01 | TPCH   |
+      |             | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      |  <null>     | Chaz          | 1993-01-01 | TPCH   |
+      |             | Don           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | <null>      | Chat          | 1993-01-01 | TPCH   |
+      |             | Doc           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-09] Simple load of identical stage data from multiple sources into an empty hub with collision keys
+    Given the HUB hub is empty
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      | 1013        | Chaz          | 1993-01-01 | TPCH   |
+      | 1014        | Don           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | 1023        | Chat          | 1993-01-01 | TPCH   |
+      | 1024        | Doc           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1013') | 1013        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1014') | 1014        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1023') | 1023        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1024') | 1024        | C             | 1993-01-01 | TPCH   |
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-10]  Keys with NULL or empty values are not loaded into a multi sourced empty hub with collision keys
+    Given the HUB hub is empty
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | <null>      | Chad          | 1993-01-01 | TPCH   |
+      |             | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1012        | Bobby         | 1993-01-01 | TPCH   |
+      |  <null>     | Chaz          | 1993-01-01 | TPCH   |
+      |             | Don           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1022        | Boby          | 1993-01-01 | TPCH   |
+      | <null>      | Chat          | 1993-01-01 | TPCH   |
+      |             | Doc           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-11] Simple load of identical stage data from multiple sources into a populated hub with collision keys
+    Given the HUB hub is already populated with data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | 1003        | Chad          | 1993-01-02 | TPCH   |
+      | 1004        | Dom           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1012        | Bobby         | 1993-01-02 | TPCH   |
+      | 1012        | Bobby         | 1993-01-02 | TPCH   |
+      | 1012        | Bobby         | 1993-01-02 | TPCH   |
+      | 1013        | Chaz          | 1993-01-02 | TPCH   |
+      | 1014        | Don           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1022        | Boby          | 1993-01-02 | TPCH   |
+      | 1022        | Boby          | 1993-01-02 | TPCH   |
+      | 1022        | Boby          | 1993-01-02 | TPCH   |
+      | 1023        | Chat          | 1993-01-02 | TPCH   |
+      | 1024        | Doc           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-02 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-02 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1013') | 1013        | B             | 1993-01-02 | TPCH   |
+      | md5('B\|\|1014') | 1014        | B             | 1993-01-02 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1023') | 1023        | C             | 1993-01-02 | TPCH   |
+      | md5('C\|\|1024') | 1024        | C             | 1993-01-02 | TPCH   |
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-12]  Keys with NULL or empty values are not loaded into a multi sourced populated hub with collision keys
+    Given the HUB hub is already populated with data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1002        | Bob           | 1993-01-02 | TPCH   |
+      | <null>      | Chad          | 1993-01-02 | TPCH   |
+      |             | Dom           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1012        | Bobby         | 1993-01-02 | TPCH   |
+      |  <null>     | Chaz          | 1993-01-02 | TPCH   |
+      |             | Don           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1001        | Alice         | 1993-01-02 | TPCH   |
+      | 1022        | Boby          | 1993-01-02 | TPCH   |
+      | <null>      | Chat          | 1993-01-02 | TPCH   |
+      |             | Doc           | 1993-01-02 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1012') | 1012        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1022') | 1022        | C             | 1993-01-01 | TPCH   |
 

--- a/test/features/hubs/hubs_collision_key.feature
+++ b/test/features/hubs/hubs_collision_key.feature
@@ -20,4 +20,53 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
-    
+
+  @fixture.multi_source_hub_with_collision_key
+  Scenario: [HUB-CK-02] Simple load of identical stage data from multiple sources into an empty hub with collision keys
+    Given the HUB table does not exist
+    And the RAW_STAGE_A table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_A data
+    And the RAW_STAGE_B table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_B data
+    And the RAW_STAGE_C table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER_C data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1001') | 1001        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1002') | 1002        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1003') | 1003        | B             | 1993-01-01 | TPCH   |
+      | md5('B\|\|1004') | 1004        | B             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1001') | 1001        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1002') | 1002        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1003') | 1003        | C             | 1993-01-01 | TPCH   |
+      | md5('C\|\|1004') | 1004        | C             | 1993-01-01 | TPCH   |
+

--- a/test/features/hubs/hubs_collision_key.feature
+++ b/test/features/hubs/hubs_collision_key.feature
@@ -1,0 +1,23 @@
+Feature: [HUB-CK] Hubs - Collision Keys
+
+  @fixture.single_source_hub_with_collision_key
+  Scenario: [HUB-CK-01] Simple load of stage data into an empty hub with collision keys
+    Given the HUB table does not exist
+    And the RAW_STAGE table contains data
+      | CUSTOMER_ID | CUSTOMER_NAME | LOAD_DATE  | SOURCE |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1001        | Alice         | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1002        | Bob           | 1993-01-01 | TPCH   |
+      | 1003        | Chad          | 1993-01-01 | TPCH   |
+      | 1004        | Dom           | 1993-01-01 | TPCH   |
+    And I stage the STG_CUSTOMER data
+    When I load the HUB hub
+    Then the HUB table should contain expected data
+      | CUSTOMER_PK      | CUSTOMER_ID | COLLISION_KEY | LOAD_DATE  | SOURCE |
+      | md5('A\|\|1001') | 1001        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1002') | 1002        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
+      | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
+    

--- a/test/features/hubs/hubs_collision_key.feature
+++ b/test/features/hubs/hubs_collision_key.feature
@@ -21,6 +21,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.single_source_hub_with_collision_key
   Scenario: [HUB-CK-02] Keys with NULL or empty values are not loaded into non existent hub with collision key that does not exist
     Given the HUB table does not exist
@@ -65,6 +66,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1003') | 1003        | A             | 1993-01-01 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-01 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.single_source_hub_with_collision_key
   Scenario: [HUB-CK-04] Keys with NULL or empty values are not loaded into empty hub with collision key that does not exist
     Given the HUB hub is empty
@@ -112,6 +114,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('A\|\|1003') | 1003        | A             | 1993-01-02 | TPCH   |
       | md5('A\|\|1004') | 1004        | A             | 1993-01-02 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.single_source_hub_with_collision_key
   Scenario: [HUB-CK-06] Keys with NULL or empty values are not loaded into populated hub with collision key that does not exist
     Given the HUB hub is already populated with data
@@ -187,6 +190,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('C\|\|1023') | 1023        | C             | 1993-01-01 | TPCH   |
       | md5('C\|\|1024') | 1024        | C             | 1993-01-01 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.multi_source_hub_with_collision_key
   Scenario: [HUB-CK-08]  Keys with NULL or empty values are not loaded into a multi sourced non existent hub with collision keys
     Given the HUB table does not exist
@@ -273,6 +277,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('C\|\|1023') | 1023        | C             | 1993-01-01 | TPCH   |
       | md5('C\|\|1024') | 1024        | C             | 1993-01-01 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.multi_source_hub_with_collision_key
   Scenario: [HUB-CK-10]  Keys with NULL or empty values are not loaded into a multi sourced empty hub with collision keys
     Given the HUB hub is empty
@@ -366,6 +371,7 @@ Feature: [HUB-CK] Hubs - Collision Keys
       | md5('C\|\|1023') | 1023        | C             | 1993-01-02 | TPCH   |
       | md5('C\|\|1024') | 1024        | C             | 1993-01-02 | TPCH   |
 
+  # todo: test fails; stage macro needs an update to deal with "null NKs + non null CKs" when creating HKs
   @fixture.multi_source_hub_with_collision_key
   Scenario: [HUB-CK-12]  Keys with NULL or empty values are not loaded into a multi sourced populated hub with collision keys
     Given the HUB hub is already populated with data


### PR DESCRIPTION
Added src_ck (collision key) to Hub macros as an optional parameter.

This will create an extra field (e.g. COLLISION_KEY) in the Hub. The field would normally be defined as a derived column in the the primed stage.

**Note**: Not all tests pass as there are some HKs with null BKs in them that are arriving in the Hub, when they shouldn't. 
- Suggested solution: update stage macro so it filters out raw data rows with any null BKs; otherwise the primed stage is 'exposed' to creating HKs on "null BKs + non-null CKs"



