### PR TITLE
Added escape_column_name for databricks.

### DIFF
--- a/dbtvault-dev/macros/internal/metadata_processing/escape_column_names.sql
+++ b/dbtvault-dev/macros/internal/metadata_processing/escape_column_names.sql
@@ -131,3 +131,14 @@
     {%- do return(escaped_column_name) -%}
 
 {%- endmacro -%}
+
+{%- macro databricks__escape_column_name(column) -%}
+
+    {%- set escape_char_left  = var('escape_char_left',  '`') -%}
+    {%- set escape_char_right = var('escape_char_right', '`') -%}
+
+    {%- set escaped_column_name = escape_char_left ~ column | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right -%}
+
+    {%- do return(escaped_column_name) -%}
+
+{%- endmacro -%}


### PR DESCRIPTION
Hi All, I added databricks__escape_column_name macro and I was able to build all my existing hubs, links and satellites which was previously targeted at sqlserver. This will hopefully help progress the full capabilities for databricks. Happy to help out if there are specific known problem areas.

Regards,

Ashley