### PR TITLE
Fix for new sqlserver pipeline error

### DIFF
--- a/.pipeline/templates/install-deps-setup-sqlserver-steps.yml
+++ b/.pipeline/templates/install-deps-setup-sqlserver-steps.yml
@@ -1,6 +1,6 @@
 steps:
   - script: sleep 10
     displayName: "Wait for SQLServer"
-  - script: sqlcmd -S localhost -U sa -P SlA7Qs3w!O -d master -i docker_scripts/sqlserver/setup.sql
+  - script: sqlcmd -S localhost -U sa -P SlA7Qs3w!O -C -d master -i docker_scripts/sqlserver/setup.sql
     displayName: "Setup SQLServer"
 

--- a/docker_scripts/sqlserver/Dockerfile
+++ b/docker_scripts/sqlserver/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/mssql/server:2019-latest
 
 ENV ACCEPT_EULA=Y
-ENV SA_PASSWORD=SlA7Qs3w!O
+ENV MSSQL_SA_PASSWORD=SlA7Qs3w!O
 ENV MSSQL_PID=Developer
 ENV PATH="$PATH:/opt/mssql-tools/bin:/opt/mssql/bin"
 

--- a/docker_scripts/sqlserver/initialisation.sh
+++ b/docker_scripts/sqlserver/initialisation.sh
@@ -2,7 +2,7 @@
 # Loop until the SQL instance is ready, up to 100 times
 for i in {1..100};
 do
-    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P SlA7Qs3w!O -d master -i setup.sql
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P SlA7Qs3w!O -C -d master -i setup.sql
     if [ $? -eq 0 ]
     then
         echo "Setup completed"


### PR DESCRIPTION
```
2022-10-12T09:28:21.2704805Z Connection:
2022-10-12T09:28:21.2705147Z   server: localhost
2022-10-12T09:28:21.2705516Z   database: DBTVAULT_DEV
2022-10-12T09:28:21.2705858Z   schema: TEST
2022-10-12T09:28:21.2706200Z   port: 1433
2022-10-12T09:28:21.2706533Z   UID: dbt_user
2022-10-12T09:28:21.2706874Z   client_id: None
2022-10-12T09:28:21.2707214Z   authentication: sql
2022-10-12T09:28:21.2707565Z   encrypt: True
2022-10-12T09:28:21.2707910Z   trust_cert: False
2022-10-12T09:28:21.2708233Z   retries: 1
2022-10-12T09:28:21.2708762Z   Connection test: [[31mERROR[0m]
2022-10-12T09:28:21.2708993Z 
2022-10-12T09:28:21.2709456Z [31m1 check failed:[0m
2022-10-12T09:28:21.2709907Z dbt was unable to connect to the specified database.
2022-10-12T09:28:21.2710381Z The database returned the following error:
2022-10-12T09:28:21.2710607Z 
2022-10-12T09:28:21.2710915Z   >Database Error
2022-10-12T09:28:21.2712085Z   ('08001', '[08001] [Microsoft][ODBC Driver 17 for SQL Server]SSL Provider: [error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:self signed certificate] (-1) (SQLDriverConnect)')
2022-10-12T09:28:21.2713103Z 
2022-10-12T09:28:21.2713546Z Check your database credentials and try again. For more information, visit:
2022-10-12T09:28:21.2714528Z https://docs.getdbt.com/docs/configure-your-profile
```

Update deprecated env variable SA_PASSWORD to MSSQL_SA_PASSWORD
Add TrustServerCertificate parameter '-C' to sqlcmd calls